### PR TITLE
Draft: fix include for uint32_t and warnings/errors with GCC 13

### DIFF
--- a/src/mustache/ecs/system.hpp
+++ b/src/mustache/ecs/system.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <mustache/utils/uncopiable.hpp>
 #include <mustache/utils/type_info.hpp>
 


### PR DESCRIPTION
Hi,
I'm getting some errors while building with GCC 13.

1. In my other Project I'm getting the error:
```bash
Error: /home/runner/work/ecs_benchmark/ecs_benchmark/build/_deps/mustache-src/src/mustache/ecs/system.hpp:27:28: error: found ‘:’ in nested-name-specifier, expected ‘::’
   27 |     enum class SystemState : uint32_t {
      |                            ^
      |                            ::
```
https://github.com/abeimler/ecs_benchmark/issues/13

_(I fix it with this PR)_


2. I'm currently trying to build mustache from master in my IDE with GCC 13 and get this warning/error:
```bash
/usr/bin/c++ -DBUILD_WITH_EASY_PROFILER=0 -Dmustache_EXPORTS -Imustache/src -Imustache/cmake-build-release -O3 -DNDEBUG -fPIC -fdiagnostics-color=always -Wall -Wextra -Werror -Wuninitialized -Wunused-parameter -Wunused-but-set-parameter -Wmissing-field-initializers -Wignored-qualifiers -Wtype-limits -Wclobbered -Wstrict-aliasing -Wimplicit-fallthrough -Wmisleading-indentation -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-include-dirs -Wnoexcept -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-promo -Wstrict-null-sentinel -Wstrict-overflow=1 -Wundef -Wno-unused -Wno-variadic-macros -Wno-parentheses -Wconversion -pedantic -fdiagnostics-show-option -MD -MT CMakeFiles/mustache.dir/src/mustache/ecs/component_mask.cpp.o -MF CMakeFiles/mustache.dir/src/mustache/ecs/component_mask.cpp.o.d -o CMakeFiles/mustache.dir/src/mustache/ecs/component_mask.cpp.o -c mustache/src/mustache/ecs/component_mask.cpp
In Datei, eingebunden von mustache/src/mustache/ecs/component_mask.cpp:5:
mustache/src/mustache/ecs/component_factory.hpp: In statischer Elementfunktion »static void mustache::ComponentFactory::moveComponent(mustache::World&, mustache::Entity, mustache::ComponentId, void*, void*, bool)«:
mustache/src/mustache/ecs/component_factory.hpp:119:25: Fehler: möglicherweise baumelnde Referenz auf temporäres Objekt [-Werror=dangling-reference]
  119 |             const auto& info = componentInfo(id);
      |                         ^~~~
mustache/src/mustache/ecs/component_factory.hpp:119:45: Anmerkung: das temporäre Objekt wurde am Ende des vollständigen Ausdrucks »mustache::ComponentFactory::componentInfo(mustache::ComponentId(id))« zerstört
  119 |             const auto& info = componentInfo(id);
      |                                ~~~~~~~~~~~~~^~~~
```

idk why the compiler thinks this is a dangling reference =/